### PR TITLE
ci: check 31.x branch [do not merge]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           key: ccache-${{ runner.os }}-${{ github.sha }}
           restore-keys: ccache-${{ runner.os }}-
       - name: Checkout Bitcoin Core
-        run: git clone --depth 1 --branch master https://github.com/bitcoin/bitcoin.git
+        run: git clone --depth 1 --branch 31.x https://github.com/bitcoin/bitcoin.git
       - name: Build Bitcoin Core
         run: |
           cd bitcoin


### PR DESCRIPTION
I'm not expecting interface changes on the Bitcoin Core 31.x branch, so this seems like a good time to create a 31.x branch here.

This PR just sanity checks that CI passes for the branch.