### PR TITLE
Add Chain interface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,12 @@ jobs:
           key: ccache-${{ runner.os }}-${{ github.sha }}
           restore-keys: ccache-${{ runner.os }}-
       - name: Checkout Bitcoin Core
-        run: git clone --depth 1 --branch master https://github.com/bitcoin/bitcoin.git
+        run: |
+          git clone --depth 1 https://github.com/bitcoin/bitcoin.git
+          # DO NOT MERGE: switch to bitcoin/bitcoin#29409 PR branch
+          cd bitcoin
+          git fetch --depth 1 origin pull/29409/head:pr-29409
+          git checkout pr-29409
       - name: Build Bitcoin Core
         run: |
           cd bitcoin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,4 +41,9 @@ jobs:
       - name: Run Test Suite
         env:
           BITCOIN_BIN: ${{ github.workspace }}/bitcoin/build/bin/bitcoin
-        run: cargo test
+        run: |
+          tests="$(cargo test --test test -- --list | sed -n 's/: test$//p')"
+          while IFS= read -r test_name; do
+            [ -n "$test_name" ] || continue
+            cargo test --test test -- --exact --test-threads=1 "$test_name"
+          done <<< "$tests"

--- a/build.rs
+++ b/build.rs
@@ -2,8 +2,10 @@ fn main() {
     println!("cargo:rerun-if-changed=capnp");
     capnpc::CompilerCommand::new()
         .src_prefix("capnp")
+        .file("capnp/chain.capnp")
         .file("capnp/common.capnp")
         .file("capnp/echo.capnp")
+        .file("capnp/handler.capnp")
         .file("capnp/init.capnp")
         .file("capnp/mining.capnp")
         .file("capnp/proxy.capnp")

--- a/capnp/chain.capnp
+++ b/capnp/chain.capnp
@@ -1,0 +1,170 @@
+# Copyright (c) The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit.
+
+@0x94f21a4864bd2c65;
+
+using Cxx = import "/capnp/c++.capnp";
+$Cxx.namespace("ipc::capnp::messages");
+
+using Proxy = import "proxy.capnp";
+
+using Common = import "common.capnp";
+using Handler = import "handler.capnp";
+
+interface Chain $Proxy.wrap("interfaces::Chain") {
+    destroy @0 (context :Proxy.Context) -> ();
+    getHeight @1 (context :Proxy.Context) -> (result :Int32, hasResult :Bool);
+    getBlockHash @2 (context :Proxy.Context, height :Int32) -> (result :Data);
+    haveBlockOnDisk @3 (context :Proxy.Context, height :Int32) -> (result :Bool);
+    findLocatorFork @4 (context :Proxy.Context, locator :Data) -> (result :Int32, hasResult :Bool);
+    hasBlockFilterIndex @5 (context :Proxy.Context, filterType :UInt8) -> (result :Bool);
+    blockFilterMatchesAny @6 (context :Proxy.Context, filterType :UInt8, blockHash :Data, filterSet :List(Data)) -> (result :Bool, hasResult :Bool);
+    findBlock @7 (context :Proxy.Context, hash :Data, block :FoundBlockParam) -> (block :FoundBlockResult, result :Bool);
+    findFirstBlockWithTimeAndHeight @8 (context :Proxy.Context, minTime :Int64, minHeight :Int32, block :FoundBlockParam) -> (block :FoundBlockResult, result :Bool);
+    findAncestorByHeight @9 (context :Proxy.Context, blockHash :Data, ancestorHeight :Int32, ancestor :FoundBlockParam) -> (ancestor :FoundBlockResult, result :Bool);
+    findAncestorByHash @10 (context :Proxy.Context, blockHash :Data, ancestorHash :Data, ancestor :FoundBlockParam) -> (ancestor :FoundBlockResult, result :Bool);
+    findCommonAncestor @11 (context :Proxy.Context, blockHash1 :Data, blockHash2 :Data, ancestor :FoundBlockParam, block1 :FoundBlockParam, block2 :FoundBlockParam) -> (ancestor :FoundBlockResult, block1 :FoundBlockResult, block2 :FoundBlockResult, result :Bool);
+    findCoins @12 (context :Proxy.Context, coins :List(Common.Pair(Data, Data))) -> (coins :List(Common.Pair(Data, Data)));
+    guessVerificationProgress @13 (context :Proxy.Context, blockHash :Data) -> (result :Float64);
+    hasBlocks @14 (context :Proxy.Context, blockHash :Data, minHeight :Int32, maxHeight: Int32, hasMaxHeight :Bool) -> (result :Bool);
+    isRBFOptIn @15 (context :Proxy.Context, tx :Data) -> (result :Int32);
+    isInMempool @16 (context :Proxy.Context, txid :Data) -> (result :Bool);
+    hasDescendantsInMempool @17 (context :Proxy.Context, txid :Data) -> (result :Bool);
+    broadcastTransaction @18 (context :Proxy.Context, tx: Data, maxTxFee :Int64, broadcastMethod :Int32) -> (error: Text, result :Bool);
+    getTransactionAncestry @19 (context :Proxy.Context, txid :Data) -> (ancestors :UInt64, descendants :UInt64, ancestorsize :UInt64, ancestorfees :Int64);
+    calculateIndividualBumpFees @20 (context :Proxy.Context, outpoints :List(Data), targetFeerate :Data) -> (result: List(Common.PairInt64(Data)));
+    calculateCombinedBumpFee @21 (context :Proxy.Context, outpoints :List(Data), targetFeerate :Data) -> (result :Int64, hasResult :Bool);
+    getPackageLimits @22 (context :Proxy.Context) -> (ancestors :UInt32, descendants :UInt32);
+    checkChainLimits @23 (context :Proxy.Context, tx :Data) -> (result :Common.ResultVoid);
+    estimateSmartFee @24 (context :Proxy.Context, numBlocks :Int32, conservative :Bool, wantCalc :Bool) -> (calc :Common.FeeCalculation, result :Data);
+    estimateMaxBlocks @25 (context :Proxy.Context) -> (result :UInt32);
+    mempoolMinFee @26 (context :Proxy.Context) -> (result :Data);
+    relayMinFee @27 (context :Proxy.Context) -> (result :Data);
+    relayIncrementalFee @28 (context :Proxy.Context) -> (result :Data);
+    relayDustFee @29 (context :Proxy.Context) -> (result :Data);
+    havePruned @30 (context :Proxy.Context) -> (result :Bool);
+    getPruneHeight @31 (context :Proxy.Context) -> (result: Int32, hasResult: Bool);
+    isReadyToBroadcast @32 (context :Proxy.Context) -> (result :Bool);
+    isInitialBlockDownload @33 (context :Proxy.Context) -> (result :Bool);
+    shutdownRequested @34 (context :Proxy.Context) -> (result :Bool);
+    initMessage @35 (context :Proxy.Context, message :Text) -> ();
+    initWarning @36 (context :Proxy.Context, message :Common.BilingualStr) -> ();
+    initError @37 (context :Proxy.Context, message :Common.BilingualStr) -> ();
+    showProgress @38 (context :Proxy.Context, title :Text, progress :Int32, resumePossible :Bool) -> ();
+    handleNotifications @39 (context :Proxy.Context, notifications :ChainNotifications) -> (result :Handler.Handler);
+    waitForNotificationsIfTipChanged @40 (context :Proxy.Context, oldTip :Data) -> ();
+    waitForNotifications @41 (context :Proxy.Context) -> ();
+    handleRpc @42 (context :Proxy.Context, command :RPCCommand) -> (result :Handler.Handler);
+    rpcEnableDeprecated @43 (context :Proxy.Context, method :Text) -> (result :Bool);
+    getSetting @44 (context :Proxy.Context, name :Text) -> (result :Text);
+    getSettingsList @45 (context :Proxy.Context, name :Text) -> (result :List(Text));
+    getRwSetting @46 (context :Proxy.Context, name :Text) -> (result :Text);
+    updateRwSetting @47 (context :Proxy.Context, name :Text, update: SettingsUpdateCallback) -> (result :Bool);
+    overwriteRwSetting @48 (context :Proxy.Context, name :Text, value :Text, action :Int32) -> (result :Bool);
+    deleteRwSettings @49 (context :Proxy.Context, name :Text, action: Int32) -> (result :Bool);
+    requestMempoolTransactions @50 (context :Proxy.Context, notifications :ChainNotifications) -> ();
+    hasAssumedValidChain @51 (context :Proxy.Context) -> (result :Bool);
+}
+
+interface ChainNotifications $Proxy.wrap("interfaces::Chain::Notifications") {
+    destroy @0 (context :Proxy.Context) -> ();
+    transactionAddedToMempool @1 (context :Proxy.Context, tx :Data) -> ();
+    transactionRemovedFromMempool @2 (context :Proxy.Context, tx :Data, reason :Int32) -> ();
+    blockConnected @3 (context :Proxy.Context, role: ChainstateRole, block :BlockInfo) -> ();
+    blockDisconnected @4 (context :Proxy.Context, block :BlockInfo) -> ();
+    updatedBlockTip @5 (context :Proxy.Context) -> ();
+    chainStateFlushed @6 (context :Proxy.Context, role: ChainstateRole, locator :Data) -> ();
+}
+
+interface ChainClient $Proxy.wrap("interfaces::ChainClient") {
+    destroy @0 (context :Proxy.Context) -> ();
+    registerRpcs @1 (context :Proxy.Context) -> ();
+    verify @2 (context :Proxy.Context) -> (result :Bool);
+    load @3 (context :Proxy.Context) -> (result :Bool);
+    start @4 (context :Proxy.Context, scheduler :Void) -> ();
+    stop @5 (context :Proxy.Context) -> ();
+    setMockTime @6 (context :Proxy.Context, time :Int64) -> ();
+    schedulerMockForward @7 (context :Proxy.Context, deltaSeconds :Int64) -> ();
+}
+
+struct RPCCommand $Proxy.wrap("CRPCCommand") {
+   category @0 :Text;
+   name @1 :Text;
+   actor @2 :ActorCallback;
+   argNames @3 :List(RPCArg);
+   uniqueId @4 :Int64 $Proxy.name("unique_id");
+}
+
+# Representation of std::pair<std::string, bool> in CRPCCommand
+struct RPCArg {
+   name @0 :Text;
+   namedOnly @1: Bool;
+}
+
+interface ActorCallback $Proxy.wrap("ProxyCallback<CRPCCommand::Actor>") {
+    call @0 (context :Proxy.Context, request :JSONRPCRequest, response :Text, lastCallback :Bool) -> (error :Text $Proxy.exception("std::exception"), rpcError :Text $Proxy.exception("UniValue"), typeError :Text $Proxy.exception("UniValue::type_error"), helpResult :HelpResult $Proxy.exception("HelpResult"), response :Text, result: Bool);
+}
+
+struct HelpResult {
+    message @0 :Text;
+}
+
+struct JSONRPCRequest $Proxy.wrap("JSONRPCRequest") {
+    id @0 :Text;
+    method @1 :Text $Proxy.name("strMethod");
+    params @2 :Text;
+    mode @3 :Int32;
+    uri @4 :Text $Proxy.name("URI");
+    authUser @5 :Text;
+    peerAddr @6 :Text;
+    version @7: Int32 $Proxy.name("m_json_version");
+}
+
+struct FoundBlockParam {
+    wantHash @0 :Bool;
+    wantHeight @1 :Bool;
+    wantTime @2 :Bool;
+    wantMaxTime @3 :Bool;
+    wantMtpTime @4 :Bool;
+    wantInActiveChain @5 :Bool;
+    wantLocator @6 :Bool;
+    nextBlock @7: FoundBlockParam;
+    wantData @8 :Bool;
+}
+
+struct FoundBlockResult {
+    hash @0 :Data;
+    height @1 :Int32;
+    time @2 :Int64;
+    maxTime @3 :Int64;
+    mtpTime @4 :Int64;
+    inActiveChain @5 :Bool;
+    locator @6 :Data;
+    nextBlock @7: FoundBlockResult;
+    data @8 :Data;
+    found @9 :Bool;
+}
+
+struct BlockInfo $Proxy.wrap("interfaces::BlockInfo") {
+    # Fields skipped below with Proxy.skip are pointer fields manually handled
+    # by CustomBuildMessage / CustomPassMessage overloads.
+    hash @0 :Data $Proxy.skip;
+    prevHash @1 :Data $Proxy.skip;
+    height @2 :Int32 = -1;
+    fileNumber @3 :Int32 = -1 $Proxy.name("file_number");
+    dataPos @4 :UInt32 = 0 $Proxy.name("data_pos");
+    data @5 :Data $Proxy.skip;
+    undoData @6 :Data $Proxy.skip;
+    chainTimeMax @7 :UInt32 = 0 $Proxy.name("chain_time_max");
+}
+
+struct ChainstateRole $Proxy.wrap("kernel::ChainstateRole") {
+    validated @0 :Bool;
+    historical @1 :Bool;
+}
+
+interface SettingsUpdateCallback $Proxy.wrap("ProxyCallback<interfaces::SettingsUpdate>") {
+    destroy @0 (context :Proxy.Context) -> ();
+    call @1 (context :Proxy.Context, value :Text) -> (value :Text, result: Int32, hasResult: Bool);
+}

--- a/capnp/common.capnp
+++ b/capnp/common.capnp
@@ -13,3 +13,52 @@ struct BlockRef $Proxy.wrap("interfaces::BlockRef") {
     hash @0 :Data;
     height @1 :Int32;
 }
+
+struct FeeCalculation $Proxy.wrap("FeeCalculation") {
+    est @0 :EstimationResult;
+    reason @1 :Int32;
+    desiredTarget @2 :Int32;
+    returnedTarget @3 :Int32;
+    bestHeight @4 :UInt32 $Proxy.name("best_height");
+}
+
+struct EstimationResult $Proxy.wrap("EstimationResult") {
+    pass @0 :EstimatorBucket;
+    fail @1 :EstimatorBucket;
+    decay @2 :Float64;
+    scale @3 :UInt32;
+}
+
+struct EstimatorBucket $Proxy.wrap("EstimatorBucket") {
+    start @0 :Float64;
+    end @1 :Float64;
+    withinTarget @2 :Float64;
+    totalConfirmed @3 :Float64;
+    inMempool @4 :Float64;
+    leftMempool @5 :Float64;
+}
+
+struct BilingualStr $Proxy.wrap("bilingual_str") {
+    original @0 :Text;
+    translated @1 :Text;
+}
+
+struct Result(Value) {
+    value @0 :Value;
+    error @1: BilingualStr;
+}
+
+# Wrapper for util::Result<void>
+struct ResultVoid(Value) {
+    error @0: BilingualStr;
+}
+
+struct Pair(Key, Value) {
+    key @0 :Key;
+    value @1 :Value;
+}
+
+struct PairInt64(Key) {
+    key @0 :Key;
+    value @1 :Int64;
+}

--- a/capnp/handler.capnp
+++ b/capnp/handler.capnp
@@ -1,0 +1,15 @@
+# Copyright (c) The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit.
+
+@0xebd8f46e2f369076;
+
+using Cxx = import "/capnp/c++.capnp";
+$Cxx.namespace("ipc::capnp::messages");
+
+using Proxy = import "proxy.capnp";
+
+interface Handler $Proxy.wrap("interfaces::Handler") {
+    destroy @0 (context :Proxy.Context) -> ();
+    disconnect @1 (context :Proxy.Context) -> ();
+}

--- a/capnp/init.capnp
+++ b/capnp/init.capnp
@@ -8,12 +8,23 @@ using Cxx = import "/capnp/c++.capnp";
 $Cxx.namespace("ipc::capnp::messages");
 
 using Proxy = import "proxy.capnp";
+using Chain = import "chain.capnp";
 using Echo = import "echo.capnp";
 using Mining = import "mining.capnp";
 
 interface Init $Proxy.wrap("interfaces::Init") {
     construct @0 (threadMap: Proxy.ThreadMap) -> (threadMap :Proxy.ThreadMap);
     makeEcho @1 (context :Proxy.Context) -> (result :Echo.Echo);
+
+    # DEPRECATED: no longer supported; server returns an error.
     makeMiningOld2 @2 () -> ();
+
     makeMining @3 (context :Proxy.Context) -> (result :Mining.Mining);
+
+    # Upstream uses ordinal @4 for `makeRpc`. This Rust crate does not bind
+    # the Rpc interface yet, but the ordinal must be present so the schema
+    # matches the wire protocol. Declared as a no-op stub.
+    makeRpcStub @4 () -> ();
+
+    makeChain @5 (context :Proxy.Context) -> (result :Chain.Chain);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,3 +3,5 @@ capnp::generated_code!(pub mod common_capnp);
 capnp::generated_code!(pub mod echo_capnp);
 capnp::generated_code!(pub mod proxy_capnp);
 capnp::generated_code!(pub mod mining_capnp);
+capnp::generated_code!(pub mod handler_capnp);
+capnp::generated_code!(pub mod chain_capnp);

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -347,6 +347,77 @@ async fn chain_basic_queries() {
     .await;
 }
 
+/// Decode a serialized `CFeeRate` blob (`SERIALIZE_METHODS(CFeeRate, obj)
+/// { READWRITE(obj.m_feerate.fee, obj.m_feerate.size); }`, where
+/// `m_feerate` is a `FeeFrac { int64_t fee; int32_t size; }`) into
+/// satoshis per kilo-vbyte, matching `CFeeRate::GetFeePerK()`.
+fn fee_rate_sat_per_kvb(blob: &[u8]) -> i64 {
+    assert_eq!(
+        blob.len(),
+        12,
+        "CFeeRate wire format is FeeFrac (int64 LE fee + int32 LE size)"
+    );
+    let fee = i64::from_le_bytes(blob[0..8].try_into().unwrap());
+    let size = i32::from_le_bytes(blob[8..12].try_into().unwrap()) as i64;
+    if size == 0 {
+        return 0;
+    }
+    fee.saturating_mul(1000) / size
+}
+
+/// Verify `Chain.relayMinFee` returns the node's minimum relay feerate as a
+/// serialized `CFeeRate` (default `DEFAULT_MIN_RELAY_TX_FEE = 100`
+/// sat/kvB). This is the IPC equivalent of `getnetworkinfo`'s `relayfee`
+/// field used by electrs's `Daemon::get_relay_fee`.
+#[tokio::test]
+#[serial_test::parallel]
+async fn chain_relay_min_fee_returns_default() {
+    with_chain_client(|_init, thread, chain| async move {
+        let mut req = chain.relay_min_fee_request();
+        req.get().get_context().unwrap().set_thread(thread.clone());
+        let resp = req.send().promise.await.unwrap();
+        let blob = resp.get().unwrap().get_result().unwrap();
+        let sat_per_kvb = fee_rate_sat_per_kvb(blob);
+        assert_eq!(
+            sat_per_kvb, 100,
+            "regtest defaults to DEFAULT_MIN_RELAY_TX_FEE = 100 sat/kvB"
+        );
+    })
+    .await;
+}
+
+/// Verify `Chain.estimateSmartFee` returns a (zeroed) `CFeeRate` blob on
+/// regtest, where the smart fee estimator has no data to work with. The
+/// shape of the response is what matters: callers must be able to decode
+/// `result :Data` as a `CFeeRate`.
+#[tokio::test]
+#[serial_test::parallel]
+async fn chain_estimate_smart_fee_returns_decodable_blob() {
+    with_chain_client(|_init, thread, chain| async move {
+        let mut req = chain.estimate_smart_fee_request();
+        req.get().get_context().unwrap().set_thread(thread.clone());
+        {
+            let mut params = req.get();
+            params.set_num_blocks(2);
+            params.set_conservative(false);
+            params.set_want_calc(false);
+        }
+        let resp = req.send().promise.await.unwrap();
+        let blob = resp.get().unwrap().get_result().unwrap();
+        let sat_per_kvb = fee_rate_sat_per_kvb(blob);
+        // Regtest has no estimator history, so we expect the "no data"
+        // sentinel of CFeeRate{} (fee=0, size=0 -> can't divide; the
+        // serializer ships zeros and we treat that as "no estimate").
+        // We tolerate either 0 or a positive value (in case a future
+        // node version returns the floor of the relay fee here).
+        assert!(
+            sat_per_kvb >= 0,
+            "estimateSmartFee should never produce a negative feerate"
+        );
+    })
+    .await;
+}
+
 /// Verify findBlock(wantData=true) returns the full serialized block. This is
 /// the call electrs uses to fetch raw blocks via IPC instead of P2P.
 #[tokio::test]
@@ -739,12 +810,9 @@ async fn chain_request_mempool_transactions_replays_current_mempool() {
         let mut req = chain.request_mempool_transactions_request();
         req.get().get_context().unwrap().set_thread(thread.clone());
         req.get().set_notifications(notifications);
-        let resp = tokio::time::timeout(
-            std::time::Duration::from_secs(15),
-            req.send().promise,
-        )
-        .await
-        .expect("requestMempoolTransactions timed out");
+        let resp = tokio::time::timeout(std::time::Duration::from_secs(15), req.send().promise)
+            .await
+            .expect("requestMempoolTransactions timed out");
         resp.expect("requestMempoolTransactions failed");
 
         // The replay is fire-and-forget on the server side; give the

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -752,7 +752,7 @@ async fn chain_handle_notifications_delivers_mempool_added() {
         req.get().get_context().unwrap().set_thread(thread.clone());
         req.get().set_notifications(notifications.clone());
         let resp = req.send().promise.await.unwrap();
-        let _handler = resp.get().unwrap().get_result().unwrap();
+        let handler = resp.get().unwrap().get_result().unwrap();
 
         // Drain any prior mempool state so the subsequent self-transfer is
         // unambiguously the trigger.
@@ -780,6 +780,10 @@ async fn chain_handle_notifications_delivers_mempool_added() {
             tokio::time::sleep(std::time::Duration::from_millis(50)).await;
         }
         inject.await.unwrap();
+
+        let mut req = handler.destroy_request();
+        req.get().get_context().unwrap().set_thread(thread.clone());
+        req.send().promise.await.unwrap();
     })
     .await;
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -6,10 +6,12 @@ mod bitcoin_core_util;
 mod bitcoin_core_wallet_util;
 
 use bitcoin_core_util::{
-    destroy_template, make_block_template, mempool_tx_count, with_init_client, with_mining_client,
+    destroy_template, make_block_template, mempool_tx_count, with_chain_client, with_init_client,
+    with_mining_client,
 };
 use bitcoin_core_wallet_util::{
     bitcoin_test_wallet, create_mempool_self_transfer, ensure_wallet_loaded_and_funded,
+    mine_blocks_to_new_address,
 };
 
 #[tokio::test]
@@ -298,4 +300,275 @@ async fn wallet_helpers_create_mempool_transaction() {
         before + 1,
         "self-transfer should add one mempool transaction"
     );
+}
+
+// -- Chain interface tests ---------------------------------------------------
+
+/// Smoke test the Chain interface bootstrap path and basic queries.
+#[tokio::test]
+#[serial_test::parallel]
+async fn chain_basic_queries() {
+    with_chain_client(|_init, thread, chain| async move {
+        // getHeight
+        let mut req = chain.get_height_request();
+        req.get().get_context().unwrap().set_thread(thread.clone());
+        let resp = req.send().promise.await.unwrap();
+        let res = resp.get().unwrap();
+        assert!(res.get_has_result(), "node should have a tip height");
+        let height: i32 = res.get_result();
+        assert!(
+            height >= 101,
+            "bootstrap helper should ensure height >= 101"
+        );
+
+        // getBlockHash at the tip
+        let mut req = chain.get_block_hash_request();
+        req.get().get_context().unwrap().set_thread(thread.clone());
+        req.get().set_height(height);
+        let resp = req.send().promise.await.unwrap();
+        let hash = resp.get().unwrap().get_result().unwrap();
+        assert_eq!(hash.len(), 32, "block hash must be 32 bytes");
+
+        // isInitialBlockDownload
+        let mut req = chain.is_initial_block_download_request();
+        req.get().get_context().unwrap().set_thread(thread.clone());
+        let resp = req.send().promise.await.unwrap();
+        let _ibd: bool = resp.get().unwrap().get_result();
+
+        // havePruned
+        let mut req = chain.have_pruned_request();
+        req.get().get_context().unwrap().set_thread(thread.clone());
+        let resp = req.send().promise.await.unwrap();
+        assert!(!resp.get().unwrap().get_result(), "regtest is not pruned");
+    })
+    .await;
+}
+
+/// Verify findBlock(wantData=true) returns the full serialized block. This is
+/// the call electrs uses to fetch raw blocks via IPC instead of P2P.
+#[tokio::test]
+#[serial_test::parallel]
+async fn chain_find_block_returns_data() {
+    with_chain_client(|_init, thread, chain| async move {
+        // Fetch the genesis block (height 0) via getBlockHash + findBlock.
+        let mut req = chain.get_block_hash_request();
+        req.get().get_context().unwrap().set_thread(thread.clone());
+        req.get().set_height(0);
+        let resp = req.send().promise.await.unwrap();
+        let genesis_hash: Vec<u8> = resp.get().unwrap().get_result().unwrap().to_vec();
+
+        let mut req = chain.find_block_request();
+        req.get().get_context().unwrap().set_thread(thread.clone());
+        req.get().set_hash(&genesis_hash);
+        {
+            let mut params = req.get().init_block();
+            params.set_want_data(true);
+            params.set_want_height(true);
+            params.set_want_hash(true);
+        }
+        let resp = req.send().promise.await.unwrap();
+        let result = resp.get().unwrap();
+        assert!(result.get_result(), "genesis block must be findable");
+        let block_result = result.get_block().unwrap();
+        let data = block_result.get_data().unwrap();
+        assert!(
+            data.len() > 80,
+            "serialized block (header + txs) must be > 80 bytes, got {}",
+            data.len()
+        );
+        let echoed_hash = block_result.get_hash().unwrap();
+        assert_eq!(echoed_hash, genesis_hash.as_slice());
+        assert_eq!(block_result.get_height(), 0);
+    })
+    .await;
+}
+
+/// Verify broadcastTransaction succeeds for a transaction that is already in
+/// the mempool. The node treats this as a re-announcement and returns OK,
+/// which is enough to exercise the request/response framing end-to-end.
+///
+/// This is the call electrs uses (when configured with the IPC backend) to
+/// replace JSON-RPC `sendrawtransaction`.
+#[tokio::test]
+#[serial_test::serial]
+async fn chain_broadcast_transaction() {
+    let wallet = bitcoin_test_wallet();
+    ensure_wallet_loaded_and_funded(&wallet);
+    let tx = create_mempool_self_transfer(&wallet);
+    let tx_bytes = encoding::encode_to_vec(&tx);
+
+    with_chain_client(|_init, thread, chain| async move {
+        let mut req = chain.broadcast_transaction_request();
+        req.get().get_context().unwrap().set_thread(thread.clone());
+        req.get().set_tx(&tx_bytes);
+        // max_tx_fee = 0 means "don't enforce a maximum"; the node will skip
+        // the test_accept fee check and re-announce the existing mempool tx.
+        req.get().set_max_tx_fee(0);
+        // node::TxBroadcast::MEMPOOL_AND_BROADCAST_TO_ALL = 0
+        req.get().set_broadcast_method(0);
+        let resp = req.send().promise.await.unwrap();
+        let r = resp.get().unwrap();
+        assert!(
+            r.get_result(),
+            "broadcastTransaction should succeed (re-announce path); error: {:?}",
+            r.get_error().ok().and_then(|e| e.to_str().ok())
+        );
+    })
+    .await;
+}
+
+/// Verify findAncestorByHeight returns the expected block hash.
+#[tokio::test]
+#[serial_test::parallel]
+async fn chain_find_ancestor_by_height() {
+    with_chain_client(|_init, thread, chain| async move {
+        // Look up the tip first.
+        let mut req = chain.get_height_request();
+        req.get().get_context().unwrap().set_thread(thread.clone());
+        let resp = req.send().promise.await.unwrap();
+        let height: i32 = resp.get().unwrap().get_result();
+
+        let mut req = chain.get_block_hash_request();
+        req.get().get_context().unwrap().set_thread(thread.clone());
+        req.get().set_height(height);
+        let resp = req.send().promise.await.unwrap();
+        let tip_hash: Vec<u8> = resp.get().unwrap().get_result().unwrap().to_vec();
+
+        // Ask for ancestor at height 50 starting from the tip.
+        let mut req = chain.find_ancestor_by_height_request();
+        req.get().get_context().unwrap().set_thread(thread.clone());
+        req.get().set_block_hash(&tip_hash);
+        req.get().set_ancestor_height(50);
+        {
+            let mut params = req.get().init_ancestor();
+            params.set_want_hash(true);
+            params.set_want_height(true);
+        }
+        let resp = req.send().promise.await.unwrap();
+        let result = resp.get().unwrap();
+        assert!(result.get_result(), "ancestor at height 50 must exist");
+        let ancestor = result.get_ancestor().unwrap();
+        assert_eq!(ancestor.get_height(), 50);
+        assert_eq!(ancestor.get_hash().unwrap().len(), 32);
+    })
+    .await;
+}
+
+/// Verify findLocatorFork returns the height of the last common block when
+/// passed a CBlockLocator containing only the genesis block hash.
+///
+/// CBlockLocator wire format (Bitcoin Core src/primitives/block.h):
+///   int32 LE version (DUMMY_VERSION = 70016) + CompactSize count + 32*count
+///   block hashes ordered tip→genesis.
+///
+/// This is the call electrs uses to find the fork point between its own
+/// header chain and the node's active chain when syncing new headers via IPC
+/// instead of P2P `getheaders`.
+#[tokio::test]
+#[serial_test::parallel]
+async fn chain_find_locator_fork() {
+    with_chain_client(|_init, thread, chain| async move {
+        // Get genesis hash via getBlockHash(0).
+        let mut req = chain.get_block_hash_request();
+        req.get().get_context().unwrap().set_thread(thread.clone());
+        req.get().set_height(0);
+        let resp = req.send().promise.await.unwrap();
+        let genesis_hash: Vec<u8> = resp.get().unwrap().get_result().unwrap().to_vec();
+        assert_eq!(genesis_hash.len(), 32);
+
+        // Build CBlockLocator { version=70016, vHave=[genesis] }.
+        let mut locator = Vec::with_capacity(4 + 1 + 32);
+        locator.extend_from_slice(&70016i32.to_le_bytes());
+        locator.push(1u8); // CompactSize for length 1
+        locator.extend_from_slice(&genesis_hash);
+
+        let mut req = chain.find_locator_fork_request();
+        req.get().get_context().unwrap().set_thread(thread.clone());
+        req.get().set_locator(&locator);
+        let resp = req.send().promise.await.unwrap();
+        let r = resp.get().unwrap();
+        assert!(
+            r.get_has_result(),
+            "fork height must be reported for genesis-only locator"
+        );
+        assert_eq!(
+            r.get_result(),
+            0,
+            "fork height for genesis-only locator must be 0"
+        );
+    })
+    .await;
+}
+
+/// Verify waitForNotificationsIfTipChanged returns immediately when the
+/// supplied `oldTip` does not match the current tip. This is the cheap
+/// no-op case (called when electrs is already aware of the latest tip).
+#[tokio::test]
+#[serial_test::parallel]
+async fn chain_wait_for_notifications_returns_immediately_when_tip_differs() {
+    with_chain_client(|_init, thread, chain| async move {
+        let mut req = chain.wait_for_notifications_if_tip_changed_request();
+        req.get().get_context().unwrap().set_thread(thread.clone());
+        // All-zeros hash is guaranteed not to be the current tip.
+        req.get().set_old_tip(&[0u8; 32]);
+        let fut = req.send().promise;
+        let result = tokio::time::timeout(std::time::Duration::from_secs(5), fut).await;
+        assert!(
+            result.is_ok(),
+            "waitForNotificationsIfTipChanged should return ~immediately when oldTip != current tip"
+        );
+        result.unwrap().unwrap();
+    })
+    .await;
+}
+
+/// Verify waitForNotificationsIfTipChanged blocks until a new block arrives
+/// when called with the current tip hash, then returns. This is the call
+/// electrs uses (when configured with the IPC backend) to replace its P2P
+/// `inv`-watching loop for new-block notifications.
+#[tokio::test]
+#[serial_test::serial]
+async fn chain_wait_for_notifications_unblocks_on_new_block() {
+    let wallet = bitcoin_test_wallet();
+    ensure_wallet_loaded_and_funded(&wallet);
+
+    with_chain_client(|_init, thread, chain| async move {
+        // Snapshot current tip.
+        let mut req = chain.get_height_request();
+        req.get().get_context().unwrap().set_thread(thread.clone());
+        let resp = req.send().promise.await.unwrap();
+        let height: i32 = resp.get().unwrap().get_result();
+
+        let mut req = chain.get_block_hash_request();
+        req.get().get_context().unwrap().set_thread(thread.clone());
+        req.get().set_height(height);
+        let resp = req.send().promise.await.unwrap();
+        let tip_hash: Vec<u8> = resp.get().unwrap().get_result().unwrap().to_vec();
+
+        // Kick off the wait *before* mining the block so we exercise the
+        // blocking path rather than the immediate-return path.
+        let mut req = chain.wait_for_notifications_if_tip_changed_request();
+        req.get().get_context().unwrap().set_thread(thread.clone());
+        req.get().set_old_tip(&tip_hash);
+        let wait_fut = req.send().promise;
+
+        // Mine one block from a separate task so we don't deadlock the
+        // current_thread runtime on the bitcoin-cli subprocess.
+        let mine_wallet = wallet.clone();
+        let mine_handle = tokio::task::spawn_blocking(move || {
+            // Small delay so the wait is established before the block lands.
+            std::thread::sleep(std::time::Duration::from_millis(200));
+            mine_blocks_to_new_address(&mine_wallet, 1)
+                .expect("failed to mine block to wake the wait");
+        });
+
+        let result = tokio::time::timeout(std::time::Duration::from_secs(15), wait_fut).await;
+        assert!(
+            result.is_ok(),
+            "waitForNotificationsIfTipChanged should unblock after a new block is mined"
+        );
+        result.unwrap().unwrap();
+        mine_handle.await.unwrap();
+    })
+    .await;
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,4 +1,7 @@
-use bitcoin_capnp_types::mining_capnp;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use bitcoin_capnp_types::{chain_capnp::chain_notifications, mining_capnp};
 
 #[path = "util/bitcoin_core.rs"]
 mod bitcoin_core_util;
@@ -569,6 +572,196 @@ async fn chain_wait_for_notifications_unblocks_on_new_block() {
         );
         result.unwrap().unwrap();
         mine_handle.await.unwrap();
+    })
+    .await;
+}
+
+/// Minimal `ChainNotifications::Server` used by the notification tests
+/// below. Records every `transactionAddedToMempool` /
+/// `transactionRemovedFromMempool` event in interior-mutable buffers so the
+/// test body can poll them. Other notification methods accept and ignore
+/// the call (they're delivered too, but the tests don't assert on them).
+#[derive(Default)]
+struct RecordingNotifications {
+    added: Rc<RefCell<Vec<Vec<u8>>>>,
+    #[allow(clippy::type_complexity)]
+    removed: Rc<RefCell<Vec<(Vec<u8>, i32)>>>,
+}
+
+impl chain_notifications::Server for RecordingNotifications {
+    fn destroy(
+        self: Rc<Self>,
+        _: chain_notifications::DestroyParams,
+        _: chain_notifications::DestroyResults,
+    ) -> impl std::future::Future<Output = Result<(), capnp::Error>> + 'static {
+        std::future::ready(Ok(()))
+    }
+
+    fn transaction_added_to_mempool(
+        self: Rc<Self>,
+        params: chain_notifications::TransactionAddedToMempoolParams,
+        _: chain_notifications::TransactionAddedToMempoolResults,
+    ) -> impl std::future::Future<Output = Result<(), capnp::Error>> + 'static {
+        let added = self.added.clone();
+        async move {
+            let p = params.get()?;
+            let tx = p.get_tx()?.to_vec();
+            added.borrow_mut().push(tx);
+            Ok(())
+        }
+    }
+
+    fn transaction_removed_from_mempool(
+        self: Rc<Self>,
+        params: chain_notifications::TransactionRemovedFromMempoolParams,
+        _: chain_notifications::TransactionRemovedFromMempoolResults,
+    ) -> impl std::future::Future<Output = Result<(), capnp::Error>> + 'static {
+        let removed = self.removed.clone();
+        async move {
+            let p = params.get()?;
+            let tx = p.get_tx()?.to_vec();
+            let reason = p.get_reason();
+            removed.borrow_mut().push((tx, reason));
+            Ok(())
+        }
+    }
+
+    fn block_connected(
+        self: Rc<Self>,
+        _: chain_notifications::BlockConnectedParams,
+        _: chain_notifications::BlockConnectedResults,
+    ) -> impl std::future::Future<Output = Result<(), capnp::Error>> + 'static {
+        std::future::ready(Ok(()))
+    }
+
+    fn block_disconnected(
+        self: Rc<Self>,
+        _: chain_notifications::BlockDisconnectedParams,
+        _: chain_notifications::BlockDisconnectedResults,
+    ) -> impl std::future::Future<Output = Result<(), capnp::Error>> + 'static {
+        std::future::ready(Ok(()))
+    }
+
+    fn updated_block_tip(
+        self: Rc<Self>,
+        _: chain_notifications::UpdatedBlockTipParams,
+        _: chain_notifications::UpdatedBlockTipResults,
+    ) -> impl std::future::Future<Output = Result<(), capnp::Error>> + 'static {
+        std::future::ready(Ok(()))
+    }
+
+    fn chain_state_flushed(
+        self: Rc<Self>,
+        _: chain_notifications::ChainStateFlushedParams,
+        _: chain_notifications::ChainStateFlushedResults,
+    ) -> impl std::future::Future<Output = Result<(), capnp::Error>> + 'static {
+        std::future::ready(Ok(()))
+    }
+}
+
+/// Verify `Chain.handleNotifications` delivers `transactionAddedToMempool`
+/// callbacks when a new transaction enters the node's mempool. This is the
+/// path electrs (when configured with the IPC backend) needs to use to
+/// retire its periodic `getrawmempool` polling.
+#[tokio::test]
+#[serial_test::serial]
+async fn chain_handle_notifications_delivers_mempool_added() {
+    let wallet = bitcoin_test_wallet();
+    ensure_wallet_loaded_and_funded(&wallet);
+
+    with_chain_client(|_init, thread, chain| async move {
+        let recorder = Rc::new(RecordingNotifications::default());
+        let recorder_for_assert = recorder.clone();
+        let notifications: chain_notifications::Client =
+            capnp_rpc::new_client_from_rc(recorder.clone());
+
+        // Register the handler. We must keep the returned Handler client
+        // alive for the duration of the subscription.
+        let mut req = chain.handle_notifications_request();
+        req.get().get_context().unwrap().set_thread(thread.clone());
+        req.get().set_notifications(notifications.clone());
+        let resp = req.send().promise.await.unwrap();
+        let _handler = resp.get().unwrap().get_result().unwrap();
+
+        // Drain any prior mempool state so the subsequent self-transfer is
+        // unambiguously the trigger.
+        recorder_for_assert.added.borrow_mut().clear();
+
+        // Inject a fresh transaction into the node's mempool from a
+        // blocking task (bitcoin-cli is sync) and wait for the notification
+        // to arrive.
+        let inject_wallet = wallet.clone();
+        let inject = tokio::task::spawn_blocking(move || {
+            create_mempool_self_transfer(&inject_wallet);
+        });
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
+        loop {
+            if !recorder_for_assert.added.borrow().is_empty() {
+                break;
+            }
+            if std::time::Instant::now() >= deadline {
+                panic!(
+                    "transactionAddedToMempool was not delivered within 15s; recorded={}",
+                    recorder_for_assert.added.borrow().len()
+                );
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+        inject.await.unwrap();
+    })
+    .await;
+}
+
+/// Verify `Chain.requestMempoolTransactions` replays the current mempool
+/// contents through the supplied `ChainNotifications` handler. This is the
+/// "give me what's already in the mempool" primer electrs needs at startup
+/// before switching to the live notification stream.
+#[tokio::test]
+#[serial_test::serial]
+async fn chain_request_mempool_transactions_replays_current_mempool() {
+    let wallet = bitcoin_test_wallet();
+    ensure_wallet_loaded_and_funded(&wallet);
+
+    // Seed the mempool with a single transaction synchronously (outside
+    // the runtime) so it's already there when we ask for the snapshot.
+    let _seed = create_mempool_self_transfer(&wallet);
+    assert!(
+        mempool_tx_count() >= 1,
+        "expected at least one tx in the node's mempool before request"
+    );
+
+    with_chain_client(|_init, thread, chain| async move {
+        let recorder = Rc::new(RecordingNotifications::default());
+        let notifications: chain_notifications::Client =
+            capnp_rpc::new_client_from_rc(recorder.clone());
+
+        let mut req = chain.request_mempool_transactions_request();
+        req.get().get_context().unwrap().set_thread(thread.clone());
+        req.get().set_notifications(notifications);
+        let resp = tokio::time::timeout(
+            std::time::Duration::from_secs(15),
+            req.send().promise,
+        )
+        .await
+        .expect("requestMempoolTransactions timed out");
+        resp.expect("requestMempoolTransactions failed");
+
+        // The replay is fire-and-forget on the server side; give the
+        // delivered callbacks a brief moment to land on our LocalSet
+        // before asserting.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            if !recorder.added.borrow().is_empty() {
+                break;
+            }
+            if std::time::Instant::now() >= deadline {
+                panic!(
+                    "requestMempoolTransactions delivered no transactionAddedToMempool callbacks"
+                );
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
     })
     .await;
 }

--- a/tests/util/bitcoin_core.rs
+++ b/tests/util/bitcoin_core.rs
@@ -8,6 +8,7 @@ use crate::bitcoin_core_wallet_util::{
     bitcoin_rpc_json, bitcoin_test_wallet, ensure_wallet_loaded, mine_blocks_to_new_address,
 };
 use bitcoin_capnp_types::{
+    chain_capnp::chain,
     init_capnp::init,
     mining_capnp::{block_template, mining},
     proxy_capnp::{thread, thread_map},
@@ -88,6 +89,18 @@ where
     .await;
 }
 
+pub async fn with_chain_client<F, Fut>(f: F)
+where
+    F: FnOnce(init::Client, thread::Client, chain::Client) -> Fut,
+    Fut: Future<Output = ()>,
+{
+    with_init_client(|client, thread| async move {
+        let chain_client = make_chain(&client, &thread).await;
+        f(client, thread, chain_client).await;
+    })
+    .await;
+}
+
 pub async fn connect_unix_stream(
     path: impl AsRef<Path>,
 ) -> VatNetwork<BufReader<Compat<OwnedReadHalf>>> {
@@ -146,6 +159,14 @@ pub async fn bootstrap(
 /// Obtain a Mining client from an Init client.
 pub async fn make_mining(init: &init::Client, thread: &thread::Client) -> mining::Client {
     let mut req = init.make_mining_request();
+    req.get().get_context().unwrap().set_thread(thread.clone());
+    let resp = req.send().promise.await.unwrap();
+    resp.get().unwrap().get_result().unwrap()
+}
+
+/// Obtain a Chain client from an Init client.
+pub async fn make_chain(init: &init::Client, thread: &thread::Client) -> chain::Client {
+    let mut req = init.make_chain_request();
     req.get().get_context().unwrap().set_thread(thread.clone());
     let resp = req.send().promise.await.unwrap();
     resp.get().unwrap().get_result().unwrap()

--- a/tests/util/bitcoin_core.rs
+++ b/tests/util/bitcoin_core.rs
@@ -67,14 +67,24 @@ where
     F: FnOnce(init::Client, thread::Client) -> Fut,
     Fut: Future<Output = ()>,
 {
+    // Per-test wall-clock cap. The happy path of every test in this file
+    // completes in a few seconds against a warm regtest node, but bugs in
+    // the wait/notification machinery (or a stuck node) can make these
+    // futures hang indefinitely -- which then ties up the CI runner until
+    // its job-level timeout fires and prints unhelpful output. Bound it
+    // here so a misbehaving test fails with a clear message instead.
+    const TEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
     let rpc_network = connect_unix_stream(unix_socket_path()).await;
     let rpc_system = RpcSystem::new(Box::new(rpc_network), None);
-    LocalSet::new()
-        .run_until(async move {
-            let (client, thread) = bootstrap(rpc_system).await;
-            f(client, thread).await;
-        })
-        .await;
+    let local = LocalSet::new();
+    let body = local.run_until(async move {
+        let (client, thread) = bootstrap(rpc_system).await;
+        f(client, thread).await;
+    });
+    tokio::time::timeout(TEST_TIMEOUT, body)
+        .await
+        .unwrap_or_else(|_| panic!("test exceeded {TEST_TIMEOUT:?} wall-clock budget"));
 }
 
 pub async fn with_mining_client<F, Fut>(f: F)

--- a/tests/util/bitcoin_core_wallet.rs
+++ b/tests/util/bitcoin_core_wallet.rs
@@ -1,4 +1,8 @@
-use std::process::Command;
+use std::{
+    io::Read,
+    process::{Command, Stdio},
+    time::{Duration, Instant},
+};
 
 use bitcoin_primitives::Transaction as BitcoinTransaction;
 use bitcoin_primitives::hex;
@@ -7,6 +11,16 @@ use serde::de::DeserializeOwned;
 
 fn bitcoin_bin() -> String {
     std::env::var("BITCOIN_BIN").unwrap_or_else(|_| "bitcoin".to_owned())
+}
+
+fn bitcoin_rpc_timeout() -> Duration {
+    const DEFAULT_TIMEOUT_SECS: u64 = 15;
+
+    std::env::var("BITCOIN_RPC_TIMEOUT_SECS")
+        .ok()
+        .and_then(|secs| secs.parse::<u64>().ok())
+        .map(Duration::from_secs)
+        .unwrap_or_else(|| Duration::from_secs(DEFAULT_TIMEOUT_SECS))
 }
 
 fn bitcoin_rpc(wallet: Option<&str>, args: &[&str]) -> Result<String, String> {
@@ -34,19 +48,57 @@ fn bitcoin_rpc_owned(wallet: Option<&str>, args: &[String]) -> Result<String, St
     }
     command.args(args);
 
-    let output = command
-        .output()
+    let rendered_args = args.join(" ");
+    let timeout = bitcoin_rpc_timeout();
+    command.stdout(Stdio::piped()).stderr(Stdio::piped());
+
+    let mut child = command
+        .spawn()
         .map_err(|e| format!("failed to execute bitcoin rpc command: {e}"))?;
-    if output.status.success() {
-        Ok(String::from_utf8(output.stdout)
-            .unwrap_or_else(|_| String::new())
-            .trim()
-            .to_owned())
-    } else {
-        Err(format!(
-            "bitcoin rpc command failed: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
-        ))
+    let start = Instant::now();
+
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                let mut stdout = Vec::new();
+                let mut stderr = Vec::new();
+                if let Some(mut pipe) = child.stdout.take() {
+                    pipe.read_to_end(&mut stdout)
+                        .map_err(|e| format!("failed to read bitcoin rpc stdout: {e}"))?;
+                }
+                if let Some(mut pipe) = child.stderr.take() {
+                    pipe.read_to_end(&mut stderr)
+                        .map_err(|e| format!("failed to read bitcoin rpc stderr: {e}"))?;
+                }
+
+                if status.success() {
+                    return Ok(String::from_utf8(stdout)
+                        .unwrap_or_else(|_| String::new())
+                        .trim()
+                        .to_owned());
+                }
+
+                return Err(format!(
+                    "bitcoin rpc command failed ({rendered_args}): {}",
+                    String::from_utf8_lossy(&stderr).trim()
+                ));
+            }
+            Ok(None) => {
+                if start.elapsed() >= timeout {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return Err(format!(
+                        "bitcoin rpc command timed out after {timeout:?} ({rendered_args})"
+                    ));
+                }
+                std::thread::sleep(Duration::from_millis(100));
+            }
+            Err(e) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(format!("failed to poll bitcoin rpc command status: {e}"));
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Corresponds to https://github.com/bitcoin/bitcoin/pull/29409

We still need to figure out which, if any, of these chain methods will be declared stable. And then if we want to limit bindings to the stable interface.

But for now, this can be used for testing.

TODO: expand test coverage