### PR TITLE
Move `capnp-rpc` to dependencies and re-export `capnp` crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,13 @@ rust-version = "1.85.0"
 
 [dependencies]
 capnp = "0.25.0"
+capnp-rpc = "0.25.0"
 
 [build-dependencies]
 capnpc = "0.25.0"
 
 [dev-dependencies]
 bitcoin-primitives = { git = "https://github.com/rust-bitcoin/rust-bitcoin", package = "bitcoin-primitives", tag = "bitcoin-0.33.0-beta" }
-capnp-rpc = "0.25.0"
 encoding = { git = "https://github.com/rust-bitcoin/rust-bitcoin", package = "bitcoin-consensus-encoding", tag = "bitcoin-0.33.0-beta" }
 futures = "0.3.0"
 serde = { version = "1", features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,3 +3,6 @@ capnp::generated_code!(pub mod common_capnp);
 capnp::generated_code!(pub mod echo_capnp);
 capnp::generated_code!(pub mod proxy_capnp);
 capnp::generated_code!(pub mod mining_capnp);
+
+pub extern crate capnp;
+pub extern crate capnp_rpc;


### PR DESCRIPTION
Closes #20 