### PR TITLE
Add submitSolution() result fields

### DIFF
--- a/capnp/mining.capnp
+++ b/capnp/mining.capnp
@@ -36,9 +36,12 @@ interface BlockTemplate $Proxy.wrap("interfaces::BlockTemplate") {
     getTxSigops @4 (context: Proxy.Context) -> (result: List(Int64));
     getCoinbaseTx @5 (context: Proxy.Context) -> (result: CoinbaseTx);
     getCoinbaseMerklePath @6 (context: Proxy.Context) -> (result: List(Data));
-    submitSolution @7 (context: Proxy.Context, version: UInt32, timestamp: UInt32, nonce: UInt32, coinbase :Data) -> (result: Bool);
+    submitSolution @10 (context: Proxy.Context, version: UInt32, timestamp: UInt32, nonce: UInt32, coinbase :Data) -> (reason: Text, debug: Text, result: Bool);
     waitNext @8 (context: Proxy.Context, options: BlockWaitOptions) -> (result: BlockTemplate);
     interruptWait @9() -> ();
+
+    # DEPRECATED: older version of submitSolution which returns an error.
+    submitSolutionOld7 @7 (context: Proxy.Context, version: UInt32, timestamp: UInt32, nonce: UInt32, coinbase :Data) -> (result: Bool);
 }
 
 struct BlockCreateOptions $Proxy.wrap("node::BlockCreateOptions") {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -36,6 +36,24 @@ async fn submit_block(
     }
 }
 
+async fn submit_solution(
+    template: &mining_capnp::block_template::Client,
+    thread: &thread::Client,
+    solution: &util::block::BlockSolution,
+) -> bool {
+    let mut req = template.submit_solution_request();
+    {
+        let mut params = req.get();
+        params.set_version(solution.version);
+        params.set_timestamp(solution.timestamp);
+        params.set_nonce(solution.nonce);
+        params.set_coinbase(&solution.coinbase);
+        params.get_context().unwrap().set_thread(thread.clone());
+    }
+    let resp = req.send().promise.await.unwrap();
+    resp.get().unwrap().get_result()
+}
+
 async fn get_template_block(
     template: &mining_capnp::block_template::Client,
     thread: &thread::Client,
@@ -338,35 +356,15 @@ async fn mining_block_template_submit_solution_resolved_and_duplicate() {
         let block = block_with_pow(&block, true);
         let solution = block_solution(&block);
 
-        let mut req = template.submit_solution_request();
-        {
-            let mut params = req.get();
-            params.set_version(solution.version);
-            params.set_timestamp(solution.timestamp);
-            params.set_nonce(solution.nonce);
-            params.set_coinbase(&solution.coinbase);
-            params.get_context().unwrap().set_thread(thread.clone());
-        }
-        let resp = req.send().promise.await.unwrap();
         assert!(
-            resp.get().unwrap().get_result(),
+            submit_solution(&template, &thread, &solution).await,
             "solved template solution must be accepted"
         );
 
         // A duplicate block currently returns true. bitcoin/bitcoin#34672 may
         // change this to false, and this coverage should catch that change.
-        let mut req = template.submit_solution_request();
-        {
-            let mut params = req.get();
-            params.set_version(solution.version);
-            params.set_timestamp(solution.timestamp);
-            params.set_nonce(solution.nonce);
-            params.set_coinbase(&solution.coinbase);
-            params.get_context().unwrap().set_thread(thread.clone());
-        }
-        let resp = req.send().promise.await.unwrap();
         assert!(
-            resp.get().unwrap().get_result(),
+            submit_solution(&template, &thread, &solution).await,
             "duplicate template solution currently returns true"
         );
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -13,7 +13,7 @@ use util::bitcoin_core_wallet::{
 };
 use util::block::{block_solution, block_with_pow};
 
-struct SubmitBlockOutcome {
+struct SubmitOutcome {
     accepted: bool,
     reason: String,
     debug: String,
@@ -23,13 +23,13 @@ async fn submit_block(
     mining: &mining_capnp::mining::Client,
     thread: &thread::Client,
     block: &[u8],
-) -> SubmitBlockOutcome {
+) -> SubmitOutcome {
     let mut req = mining.submit_block_request();
     req.get().get_context().unwrap().set_thread(thread.clone());
     req.get().set_block(block);
     let resp = req.send().promise.await.unwrap();
     let results = resp.get().unwrap();
-    SubmitBlockOutcome {
+    SubmitOutcome {
         accepted: results.get_result(),
         reason: results.get_reason().unwrap().to_string().unwrap(),
         debug: results.get_debug().unwrap().to_string().unwrap(),
@@ -40,7 +40,7 @@ async fn submit_solution(
     template: &mining_capnp::block_template::Client,
     thread: &thread::Client,
     solution: &util::block::BlockSolution,
-) -> bool {
+) -> SubmitOutcome {
     let mut req = template.submit_solution_request();
     {
         let mut params = req.get();
@@ -51,7 +51,12 @@ async fn submit_solution(
         params.get_context().unwrap().set_thread(thread.clone());
     }
     let resp = req.send().promise.await.unwrap();
-    resp.get().unwrap().get_result()
+    let results = resp.get().unwrap();
+    SubmitOutcome {
+        accepted: results.get_result(),
+        reason: results.get_reason().unwrap().to_string().unwrap(),
+        debug: results.get_debug().unwrap().to_string().unwrap(),
+    }
 }
 
 async fn get_template_block(
@@ -345,6 +350,30 @@ async fn mining_block_template_lifecycle() {
     .await;
 }
 
+/// submitSolution with insufficient PoW should return reason/debug details.
+#[tokio::test]
+#[serial_test::serial]
+async fn mining_block_template_submit_solution_insufficient_pow() {
+    with_mining_client(|_client, thread, mining| async move {
+        let template = make_block_template(&mining, &thread).await;
+
+        let block = get_template_block(&template, &thread).await;
+        let block = block_with_pow(&block, false);
+        let solution = block_solution(&block);
+
+        let outcome = submit_solution(&template, &thread, &solution).await;
+        assert!(
+            !outcome.accepted,
+            "solution with insufficient PoW must not be accepted"
+        );
+        assert_eq!(outcome.reason, "high-hash");
+        assert_eq!(outcome.debug, "proof of work failed");
+
+        destroy_template(&template, &thread).await;
+    })
+    .await;
+}
+
 /// submitSolution with a solved template block should be accepted.
 #[tokio::test]
 #[serial_test::serial]
@@ -356,17 +385,19 @@ async fn mining_block_template_submit_solution_resolved_and_duplicate() {
         let block = block_with_pow(&block, true);
         let solution = block_solution(&block);
 
+        let outcome = submit_solution(&template, &thread, &solution).await;
         assert!(
-            submit_solution(&template, &thread, &solution).await,
-            "solved template solution must be accepted"
+            outcome.accepted,
+            "solved template solution must be accepted: reason={}, debug={}",
+            outcome.reason, outcome.debug
         );
+        assert_eq!(outcome.reason, "");
+        assert_eq!(outcome.debug, "");
 
-        // A duplicate block currently returns true. bitcoin/bitcoin#34672 may
-        // change this to false, and this coverage should catch that change.
-        assert!(
-            submit_solution(&template, &thread, &solution).await,
-            "duplicate template solution currently returns true"
-        );
+        let outcome = submit_solution(&template, &thread, &solution).await;
+        assert!(!outcome.accepted, "duplicate solution must not be accepted");
+        assert_eq!(outcome.reason, "duplicate");
+        assert_eq!(outcome.debug, "");
 
         destroy_template(&template, &thread).await;
     })


### PR DESCRIPTION
This updates `submitSolution()` for https://github.com/bitcoin/bitcoin/pull/34672 so it returns `reason` and `debug`, matching `submitBlock()`.

This PR also adds minimal coverage for the new result fields.

To be merged after:
- https://github.com/bitcoin/bitcoin/pull/34672
  - CI branch needs to be switched back to master